### PR TITLE
Add "local_ip_address" option when discovering devices

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -19,7 +19,7 @@ declare class Broadlink extends EventEmitter {
     /**
      * Start the discovery procedure
      */
-    discover(): void;
+    discover(local_ip_address?: string): void;
 }
 
 declare namespace Broadlink {

--- a/index.js
+++ b/index.js
@@ -107,19 +107,23 @@ Broadlink.prototype.genDevice = function(devtype, host, mac) {
     }
 }
 
-Broadlink.prototype.discover = function() {
+Broadlink.prototype.discover = function(local_ip_address) {
     self = this;
     var interfaces = os.networkInterfaces();
-    var addresses = [];
-    for (var k in interfaces) {
-        for (var k2 in interfaces[k]) {
-            var address = interfaces[k][k2];
-            if (address.family === 'IPv4' && !address.internal) {
-                addresses.push(address.address);
+    if (local_ip_address) {
+        var address = local_ip_address.split('.');
+    } else {
+        var addresses = [];
+        for (var k in interfaces) {
+            for (var k2 in interfaces[k]) {
+                var address = interfaces[k][k2];
+                if (address.family === 'IPv4' && !address.internal) {
+                    addresses.push(address.address);
+                }
             }
         }
+        var address = addresses[0].split('.');
     }
-    var address = addresses[0].split('.');
     var cs = dgram.createSocket({ type: 'udp4', reuseAddr: true });
     cs.on('listening', function() {
         cs.setBroadcast(true);

--- a/index.js
+++ b/index.js
@@ -111,7 +111,7 @@ Broadlink.prototype.discover = function(local_ip_address) {
     self = this;
     var interfaces = os.networkInterfaces();
     if (local_ip_address) {
-        var address = local_ip_address.split('.');
+        var address = local_ip_address;
     } else {
         var addresses = [];
         for (var k in interfaces) {
@@ -122,7 +122,7 @@ Broadlink.prototype.discover = function(local_ip_address) {
                 }
             }
         }
-        var address = addresses[0].split('.');
+        var address = addresses[0];
     }
     var cs = dgram.createSocket({ type: 'udp4', reuseAddr: true });
     cs.on('listening', function() {
@@ -157,10 +157,11 @@ Broadlink.prototype.discover = function(local_ip_address) {
         packet[0x11] = now.getDay();
         packet[0x12] = now.getDate();
         packet[0x13] = now.getMonth();
-        packet[0x18] = parseInt(address[0]);
-        packet[0x19] = parseInt(address[1]);
-        packet[0x1a] = parseInt(address[2]);
-        packet[0x1b] = parseInt(address[3]);
+        var address_parts = address.split('.');
+        packet[0x18] = parseInt(address_parts[0]);
+        packet[0x19] = parseInt(address_parts[1]);
+        packet[0x1a] = parseInt(address_parts[2]);
+        packet[0x1b] = parseInt(address_parts[3]);
         packet[0x1c] = port & 0xff;
         packet[0x1d] = port >> 8;
         packet[0x26] = 6;

--- a/index.js
+++ b/index.js
@@ -207,7 +207,7 @@ Broadlink.prototype.discover = function(local_ip_address) {
         //console.log('===Server Closed');
     });
 
-    cs.bind();
+    cs.bind(0, address);
 
     setTimeout(function() {
         cs.close();


### PR DESCRIPTION
This update added a "local_ip_address" option just as in the python-broadlink api . This option is quite useful if multiple network interfaces exist and the one connecting to the target device is not the first. Also node's os.networkInterfaces cannot find all interfaces in some cases where providing a binding address may become a must (issue https://github.com/nodejs/node/issues/498).

## Use/test case with homebridge-broadlink-platform:

My raspberry pi connected to a router via eth0 along with my iphone. The raspberry pi also has a wireless interface wlan0 which I set as an AP. The network on eth0 has ip 192.168.0.10 and the network on wlan0 has ip 192.168.42.1. An SP1 device connected to wlan0.

Now if without the "local_ip_address" option, when sending the broadcast message to 255.255.255.255, the packet will be sent through only one (random) interface (see https://stackoverflow.com/questions/683624/udp-broadcast-on-all-interfaces) and perhaps under the network 192.168.0. Thus , it will not reach my SP1. By this update we can provide local_ip_address as 192.168.42.1 to solve the problem.

To achieve the above the homebridge-broadlink-platform package also has to be updated. I will submitted a pull request there: https://github.com/smka/homebridge-broadlink-platform/pull/9.

## Changes

This update only add a conditional branch. Otherwise the only change is that the socket is bound to the calculated address instead of the default (0.0.0.0), which is a rational change in my opinion.